### PR TITLE
No apachemod php8.2

### DIFF
--- a/images/php-8.2/Dockerfile
+++ b/images/php-8.2/Dockerfile
@@ -2,6 +2,13 @@ FROM wexample/php-common:latest
 
 COPY ./addons/services-php/images/php-8.2/entrypoint.sh /docker-entrypoint-php8.sh
 
+# The image php-common comes with libapache2-mod-php which makes Apache uses the
+# prefork model. Since we use php-fpm, we switch to the more efficient 'event'
+RUN apt-get purge -yq libapache2-mod-php && \
+  apt-get autoremove -yq --purge && \
+  a2dismod mpm_prefork && \
+  a2enmod mpm_event
+
 RUN apt-get update -yq && \
   apt-get install -yq \
   php8.2 \

--- a/images/php-8.2/entrypoint.sh
+++ b/images/php-8.2/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+service apache2 start
+service php8.2-fpm start
+
 # Load parent entry point.
 . /docker-entrypoint-ubuntu.sh


### PR DESCRIPTION
This pull-request removes the (a priori) unused packages `libapache2-mod-php` and `libapache2-mod-php8.2` and configures Apache to use the lighter and more efficient `event` MPM.

It also starts the apache2 and php-fpm8.2 services at the container boot.